### PR TITLE
Potential fix for code scanning alert no. 19: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 rcssmin
+argon2-cffi==25.1.0
 rjsmin
 cryptography
 flask


### PR DESCRIPTION
Potential fix for [https://github.com/TheHSI-HQ/Pyromanic/security/code-scanning/19](https://github.com/TheHSI-HQ/Pyromanic/security/code-scanning/19)

The single best way to fix this issue is to switch from using MD5, SHA-256, or SHA-512 to a dedicated password hashing library that is designed to be computationally expensive and to include password-specific handling (automatically using salts, etc). The recommended approach is to use the `argon2-cffi` package, which provides the Argon2 password hashing algorithm. This algorithm will securely generate hashes and verify them in a manner suited for authenticating users.

To fix the issue:
- Replace the custom multi-hash construction in both `Auth.create_user` and `Auth.verify_user` with Argon2's `PasswordHasher().hash()` and `PasswordHasher().verify()` methods.
- Store the output of `PasswordHasher().hash(password + secret)` for each user and use `PasswordHasher().verify(stored_hash, password + secret)` for verification.
- Update imports to add Argon2's `PasswordHasher`.
- Remove the use of MD5, SHA-256, SHA-512 for password hashing.
- Ensure all regions constructing, storing, and verifying password hashes use Argon2.

You only need to change code in `libs/auth.py`. No changes are needed in `libs/config.py`. The config secret can still be appended to the password if desired.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
