### PR TITLE
Potential fix for code scanning alert no. 13: Uncontrolled data used in path expression

### DIFF
--- a/routes/resources.py
+++ b/routes/resources.py
@@ -5,7 +5,7 @@ from libs.metrics import Metrics
 from libs.config import load_reloading_config, read_config
 from yaml import safe_load
 from os.path import exists
-
+import os
 cfg = load_reloading_config('pyromanic.yaml')
 metrics = Metrics()
 
@@ -64,8 +64,17 @@ def img_provider(path: str):
             return Response("Failed to Read Metadata", 500, mimetype="text/text")
         formats = metadata["formats"]
         default = metadata["default"]
+        img_root = os.path.abspath("./www/img/")
         if format in formats:
-            return send_file("./www/img/" + t_path + "/" + formats[format])
+            candidate_path = os.path.normpath(os.path.join("./www/img/", t_path, formats[format]))
+            candidate_fullpath = os.path.abspath(candidate_path)
+            if not candidate_fullpath.startswith(img_root + os.sep):
+                return Response("Forbidden", 403)
+            return send_file(candidate_fullpath)
         else:
-            return send_file("./www/img/" + t_path + "/" + formats[default])
+            candidate_path = os.path.normpath(os.path.join("./www/img/", t_path, formats[default]))
+            candidate_fullpath = os.path.abspath(candidate_path)
+            if not candidate_fullpath.startswith(img_root + os.sep):
+                return Response("Forbidden", 403)
+            return send_file(candidate_fullpath)
     return Response("Failed to Compile CSS", 500, mimetype="text/text")


### PR DESCRIPTION
Potential fix for [https://github.com/TheHSI-HQ/Pyromanic/security/code-scanning/13](https://github.com/TheHSI-HQ/Pyromanic/security/code-scanning/13)

To fix the problem, we should ensure that the file path constructed from potentially user-controlled data (`t_path` and `formats[default]`) cannot escape the intended directory (`./www/img/`). The best general strategy is to (a) use `os.path.normpath` to normalize the constructed path, removing any traversal sequences, and (b) check that the resulting path starts with the intended root directory (`./www/img/`). The check must be performed after normalization, and before using `send_file`.

Specifically, in both lines 68 and 70, construct the full path using `os.path.join` and `os.path.normpath`, then check that the normalized path starts with `os.path.abspath("./www/img/")`. If it doesn't, return a 403 or error response. Add the required import for `os` if not already present.

Edit these regions:
- Add `import os` at the top.
- For both usage of `send_file`, normalize and validate the full path before passing to `send_file`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
