### PR TITLE
Potential fix for code scanning alert no. 7: Uncontrolled data used in path expression

### DIFF
--- a/routes/resources.py
+++ b/routes/resources.py
@@ -14,9 +14,14 @@ resources = Blueprint('resources', __name__, template_folder='../www/templates',
 @resources.route("/res/css/<string:path>.css")
 @metrics.measure
 def css_provider(path: str):
-    if not exists("./www/css/" + path + ".css"):
+    css_root = os.path.abspath("./www/css/")
+    candidate_path = os.path.normpath(os.path.join("./www/css/", path + ".css"))
+    candidate_fullpath = os.path.abspath(candidate_path)
+    if not candidate_fullpath.startswith(css_root + os.sep):
+        return Response("Forbidden", 403)
+    if not exists(candidate_fullpath):
         return "<h1>404 Not Found</h1>", 404
-    with open("./www/css/" + path + ".css", 'r') as f:
+    with open(candidate_fullpath, 'r') as f:
         read = f.read()
 
         base = read_config(cfg(), 'app.base_path', str).removesuffix("/")


### PR DESCRIPTION
Potential fix for [https://github.com/TheHSI-HQ/Pyromanic/security/code-scanning/7](https://github.com/TheHSI-HQ/Pyromanic/security/code-scanning/7)

To fix this vulnerability, we must ensure that any path constructed using user-controlled data stays within the intended directory (`./www/css/`). The best practice is to build the candidate path, normalize it (with `os.path.normpath` or `os.path.abspath`), and check that the resulting path is still inside the intended base directory. If not, return an error (404/403). This should be done before checking file existence (`exists`) or opening the file.

- **Where:**  
  Edit the `css_provider` function in `routes/resources.py`, lines 17–19 and related logic.
- **How:**  
  - Create a `base_path` variable for the CSS root (recommended: use absolute path for comparison).
  - Join user-provided path (plus `.css`) to `base_path` using `os.path.join`.
  - Normalize and make the resulting path absolute (`os.path.abspath` or `os.path.realpath`).
  - Check if the resulting path starts with the correct CSS directory (plus separator, to avoid prefix hit).
  - If not, return error (403 Forbidden).
  - Use this cleaned path for `exists` and `open`.
- **Imports:**  
  Use standard `os.path` operations already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
