### PR TITLE
Potential fix for code scanning alert no. 15: Failure to use secure cookies

### DIFF
--- a/routes/setup.py
+++ b/routes/setup.py
@@ -33,5 +33,11 @@ def setup_account():
 
     auth.create_user(request.form["username"], request.form["password"], "operator")
     resp = make_response(redirect("/"))
-    resp.set_cookie('PYRO-AuthKey', auth.register_cookie(request.form["username"]))
+    resp.set_cookie(
+        'PYRO-AuthKey',
+        auth.register_cookie(request.form["username"]),
+        secure=True,
+        httponly=True,
+        samesite='Strict'
+    )
     return resp


### PR DESCRIPTION
Potential fix for [https://github.com/TheHSI-HQ/Pyromanic/security/code-scanning/15](https://github.com/TheHSI-HQ/Pyromanic/security/code-scanning/15)

The optimal fix is to explicitly add the recommended security attributes to the call to `resp.set_cookie` in `setup_account`:
- Set `secure=True` to ensure the cookie is only sent over HTTPS.
- Set `httponly=True` to prevent JavaScript access to the cookie.
- Set `samesite='Strict'` (or `'Lax'`). `'Strict'` offers the highest protection against CSRF.
This fix is implemented by modifying the call at line 36 in `routes/setup.py`, without changing existing functionality. No additional imports or definitions are needed as these are standard arguments for Flask's `set_cookie` method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
