### PR TITLE
Potential fix for code scanning alert no. 14: Failure to use secure cookies

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -61,7 +61,7 @@ def letmein():
 
     if authentication.verify_user(request.form["username"], request.form["password"]):
         resp = make_response(redirect(unquote_plus(request.args["url"])) if "url" in request.args else redirect("/"))
-        resp.set_cookie('PYRO-AuthKey', authentication.register_cookie(request.form["username"]))
+        resp.set_cookie('PYRO-AuthKey', authentication.register_cookie(request.form["username"]), secure=True, httponly=True, samesite='Strict')
         return resp
 
     if ip:


### PR DESCRIPTION
Potential fix for [https://github.com/TheHSI-HQ/Pyromanic/security/code-scanning/14](https://github.com/TheHSI-HQ/Pyromanic/security/code-scanning/14)

To properly secure the `'PYRO-AuthKey'` cookie, set the following attributes when calling `resp.set_cookie()`:
- `secure=True` ensures the cookie is only sent over HTTPS connections.
- `httponly=True` prevents JavaScript running in the client from accessing the cookie, mitigating risk from XSS attacks.
- `samesite='Strict'` (or `'Lax'` if your usecase requires less restrictive cross-site usage) prevents the cookie from being sent on cross-site requests, reducing CSRF risk.

To implement the fix, edit line 64 in file `routes/auth.py` to pass these keyword arguments to the `set_cookie` call:

```python
resp.set_cookie('PYRO-AuthKey', authentication.register_cookie(request.form["username"]), secure=True, httponly=True, samesite='Strict')
```

No new imports or method definitions are needed, as these parameters are directly supported in the Flask `set_cookie` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
