### PR TITLE
Potential fix for code scanning alert no. 5: URL redirection from remote source

### DIFF
--- a/routes/landing.py
+++ b/routes/landing.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, request, redirect
-from urllib.parse import unquote_plus
+from urllib.parse import unquote_plus, urlparse
 from libs.auth import Auth
 from libs.preprocessor import render_template_string
 from libs.config import load_reloading_config, read_config
@@ -22,8 +22,12 @@ def index():
 
     if auth.is_valid_cookie(request.cookies.get("PYRO-AuthKey", type=str)):
         if "url" in request.args:
-            return redirect(unquote_plus(request.args["url"]))
-        return redirect("/")
+            url = unquote_plus(request.args["url"]).replace('\\', '')
+            parsed = urlparse(url)
+            # Only redirect to relative URLs (no netloc, no scheme)
+            if not parsed.netloc and not parsed.scheme:
+                return redirect(url)
+            return redirect("/")
 
     if "c" in request.args:
         code = request.args["c"]


### PR DESCRIPTION
Potential fix for [https://github.com/TheHSI-HQ/Pyromanic/security/code-scanning/5](https://github.com/TheHSI-HQ/Pyromanic/security/code-scanning/5)

The right way to fix this issue is to ensure the application never redirects to a location based solely on user input unless it validates that the destination is within a set of allowed locations, or at least is restricted to local/relative URLs. Since the set of valid redirection URLs may not be known ahead of time, the recommended fix is to validate that the URL is not an absolute/remote address using Python's `urllib.parse.urlparse`. This involves replacing backslashes in the URL, then checking both `.netloc` and `.scheme` attributes to ensure only relative URLs are redirected; otherwise, redirect to a safe fallback, like the root.

- You should edit only the logic inside the `index` function in `routes/landing.py`.
- Add an import for `urlparse` from `urllib.parse`, if not already present.
- In the block where `"url"` is in `request.args`, before calling `redirect`, validate the URL using the method described above (replace backslashes, check for netloc/scheme).
- If validation fails, redirect to `"/"` instead.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
