### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish-commit.yml
+++ b/.github/workflows/docker-publish-commit.yml
@@ -15,6 +15,8 @@ on:
       - ".github/workflows/docker-publish.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
 jobs:
   build-and-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/TheHSI-HQ/Pyromanic/security/code-scanning/1](https://github.com/TheHSI-HQ/Pyromanic/security/code-scanning/1)

To fix this problem, you should add an explicit `permissions` block to the workflow to limit the permissions granted to the `GITHUB_TOKEN` during workflow execution. Since this workflow does not require write permissions (it builds/pushes Docker images, with authentication via secrets, and does not interact with the repository in a way requiring write access), the minimal required permissions for this case are `contents: read`. You should add the `permissions` block at the root of the workflow file, above the `jobs:` key, so that all jobs inherit these restricted permissions unless overridden. No imports or additional methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
