### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,6 @@
 name: Build and Publish Docker Image (Tag)
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/TheHSI-HQ/Pyromanic/security/code-scanning/2](https://github.com/TheHSI-HQ/Pyromanic/security/code-scanning/2)

To fix this problem, you should add a `permissions:` block to the workflow or to the specific job that needs limited access, specifying the least privilege necessary. In this case, as the workflow's steps are only accessing the repository to checkout code and pushing images to Docker registries, the `contents: read` permission is likely sufficient. This should be added at the workflow root (top-level), so it applies to all jobs unless overridden elsewhere. Specifically, add:

```yaml
permissions:
  contents: read
```

immediately below the `name:` and before the `on:` key in `.github/workflows/docker-publish.yml`. No additional imports or definitions are needed for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
